### PR TITLE
Improve image banner accessibility

### DIFF
--- a/assets/section-image-banner.css
+++ b/assets/section-image-banner.css
@@ -395,6 +395,10 @@
   height: 100%;
 }
 
+.banner--split::after {
+  display: none;
+}
+
 .banner__box > * + .banner__text {
   margin-top: 1.5rem;
 }
@@ -488,5 +492,30 @@
   .banner--desktop-transparent .inline-richtext a:hover,
   .banner--desktop-transparent .rte a:hover {
     color: currentColor;
+  }
+}
+
+.banner--split {
+  position: relative;
+}
+
+.banner--split .banner__media {
+  position: relative;
+  width: 50%;
+}
+
+.banner--split .banner__content {
+  position: relative;
+  width: 50%;
+}
+
+@media screen and (max-width: 749px) {
+  .banner--split {
+    flex-direction: column;
+  }
+
+  .banner--split .banner__media,
+  .banner--split .banner__content {
+    width: 100%;
   }
 }

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -3,7 +3,6 @@
 {%- if section.settings.image_height == 'adapt' and section.settings.image != blank -%}
   {%- style -%}
     @media screen and (max-width: 749px) {
-      #Banner-{{ section.id }}::before,
       #Banner-{{ section.id }} .banner__media::before,
       #Banner-{{ section.id }}:not(.banner--mobile-bottom) .banner__content::before {
         padding-bottom: {{ 1 | divided_by: section.settings.image.aspect_ratio | times: 100 }}%;
@@ -13,7 +12,6 @@
     }
 
     @media screen and (min-width: 750px) {
-      #Banner-{{ section.id }}::before,
       #Banner-{{ section.id }} .banner__media::before {
         padding-bottom: {{ 1 | divided_by: section.settings.image.aspect_ratio | times: 100 }}%;
         content: '';
@@ -24,7 +22,7 @@
 {%- endif -%}
 
 {%- style -%}
-  #Banner-{{ section.id }}::after {
+  #Banner-{{ section.id }} .banner__media::after {
     opacity: {{ section.settings.image_overlay_opacity | divided_by: 100.0 }};
   }
   /* ✅ 添加模块下边距，统一首页节奏感 */
@@ -53,11 +51,17 @@
   if section.index == 1
     assign fetch_priority = 'high'
   endif
+  assign banner_image_alt = section.settings.image.alt | escape
+  assign banner_image_alt_2 = section.settings.image_2.alt | escape
+  assign loading = 'lazy'
+  if section.index == 1
+    assign loading = 'eager'
+  endif
 -%}
 
 <div
   id="Banner-{{ section.id }}"
-  class="banner banner--content-align-{{ section.settings.desktop_content_alignment }} banner--content-align-mobile-{{ section.settings.mobile_content_alignment }} banner--{{ section.settings.image_height }}{% if section.settings.stack_images_on_mobile and section.settings.image != blank and section.settings.image_2 != blank %} banner--stacked{% endif %}{% if section.settings.image_height == 'adapt' and section.settings.image != blank %} banner--adapt{% endif %}{% if section.settings.show_text_below %} banner--mobile-bottom{%- endif -%}{% if section.settings.show_text_box == false %} banner--desktop-transparent{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+  class="banner banner--split banner--content-align-{{ section.settings.desktop_content_alignment }} banner--content-align-mobile-{{ section.settings.mobile_content_alignment }} banner--{{ section.settings.image_height }}{% if section.settings.stack_images_on_mobile and section.settings.image != blank and section.settings.image_2 != blank %} banner--stacked{% endif %}{% if section.settings.image_height == 'adapt' and section.settings.image != blank %} banner--adapt{% endif %}{% if section.settings.show_text_below %} banner--mobile-bottom{%- endif -%}{% if section.settings.show_text_box == false %} banner--desktop-transparent{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
 >
   {%- if section.settings.image != blank -%}
     <div class="banner__media media{% if section.settings.image == blank and section.settings.image_2 == blank %} placeholder{% endif %}{% if section.settings.image_2 != blank %} banner__media-half{% endif %}{% if section.settings.image_behavior != 'none' %} animate--{{ section.settings.image_behavior }}{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}">
@@ -81,6 +85,8 @@
           width: section.settings.image.width,
           height: image_height,
           class: image_class,
+          loading: loading,
+          alt: banner_image_alt,
           sizes: sizes,
           widths: widths,
           fetchpriority: fetch_priority
@@ -113,6 +119,8 @@
           width: section.settings.image_2.width,
           height: image_height_2,
           class: image_class_2,
+          loading: loading,
+          alt: banner_image_alt_2,
           sizes: sizes,
           widths: widths,
           fetchpriority: fetch_priority


### PR DESCRIPTION
## Summary
- add alt and loading attributes to image banner images
- introduce variables for alt text and loading mode
- tweak styles so the banner image displays on the left with text to the right

## Testing
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68832b4eb0a88321a00f0f7ba551806e